### PR TITLE
fix/ntlm_auth

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 	)
 	params := winrm.DefaultParameters
 
-	if *auth == "NTML" {
+	if *auth == "NTLM" {
 		params.TransportDecorator = func() winrm.Transporter { return &winrm.ClientNTLM{} }
 	}
 


### PR DESCRIPTION
Fixes check for NTLM auth which has a typo and checked for `NTML` instead of `NTLM`